### PR TITLE
Signal import

### DIFF
--- a/PMAT/probabilistic_map_algebra_tool.py
+++ b/PMAT/probabilistic_map_algebra_tool.py
@@ -5,7 +5,8 @@
 #------------------------------------------------------------------------------
 
 #Universal packages
-from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication, QThread, Signal, QMutex, QFileInfo
+from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication, QThread, QMutex, QFileInfo
+from PyQt4.QtCore import pyqtSignal as Signal
 from PyQt4.QtGui import QAction, QIcon, QDialog, QDialogButtonBox, QFileDialog, QMessageBox 
 from qgis.core import *
 from qgis.gui import *


### PR DESCRIPTION
Changed Signal to pyqtSignal, don't know yet whether this is really needed for new versions of PyQt4, however, have found this naming in all references to PyQt, while Signal is only used in PySide. 